### PR TITLE
delete checkmark to submit points, no longer needed

### DIFF
--- a/src/components/Point.tsx
+++ b/src/components/Point.tsx
@@ -81,7 +81,6 @@ const Point = (props: any) => {
             onFocus={() => setIsEditing(point.pointId)}
             onBlur={handleBlur}
           />
-          {isEditing && point.content && <input type="submit" value="✓" />}
           <button
             type="button"
             onClick={() => {


### PR DESCRIPTION
this resolves the issue of not being able to easily click the X mark while point has focus (is being edited)