### PR TITLE
* replaced textarea with ContentEditable

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bootstrap": "^4.5.0",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.1",
-    "react-contenteditable": "^3.3.4",
+    "react-contenteditable": "^3.3.5",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
     "styled-components": "^5.1.1",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,36 @@
+/*
+  Copyright (C) 2020 by USHIN, Inc.
+
+  This file is part of U4U.
+
+  U4U is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  U4U is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with U4U.  If not, see <https://www.gnu.org/licenses/>.
+*/
+import React from "react";
+import styled from "styled-components";
+
+const Button = (props: any) => {
+  const { onClick } = props;
+  return (
+    <StyledButton type="button" onClick={onClick}>
+      ⨯
+    </StyledButton>
+  );
+};
+
+const StyledButton = styled.button`
+  border: 0px;
+  background-color: #eee;
+`;
+
+export default Button;

--- a/src/components/Region.tsx
+++ b/src/components/Region.tsx
@@ -64,6 +64,7 @@ const Region = (props: {
             messageDispatch={messageDispatch}
             isEditing={editingPoint === p.pointId ? true : false}
             setEditingPoint={setEditingPoint}
+            createEmptyPoint={() => createEmptyPoint(region)}
             onClick={() => onRegionClick(region, true)}
           />
         ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8792,10 +8792,10 @@ react-bootstrap@^1.0.1:
     uncontrollable "^7.0.0"
     warning "^4.0.3"
 
-react-contenteditable@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/react-contenteditable/-/react-contenteditable-3.3.4.tgz#32cb61b026341407afda3ba8a281b4a82bdb9232"
-  integrity sha512-pxn0YUJWOXSUhl4NZu8Za5ul+M5bCmSPH1p899AkWDE+cewROn+9uucwKE79YkZg8p7WpK5uo1nhEbYOsuoIUQ==
+react-contenteditable@^3.3.5:
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/react-contenteditable/-/react-contenteditable-3.3.5.tgz#febff7a46570fdb2f5ff199e506c512e5924e22e"
+  integrity sha512-38A7hlRQfb2KQAQT0kIJC2YlQUU7jcyYM4eh1fj6kAYb3Hmk6hHlr0snelyxVSpPXjPdFllrnSsPkzUS5AtrEA==
   dependencies:
     fast-deep-equal "^2.0.1"
     prop-types "^15.7.1"


### PR DESCRIPTION
	* react-contenteditable was already in package.json and yarn.lock - now updated)
* pass createEmptyPoint from Region to Point to allow creating new points on pressing enter
* extracted Button.tsx component from Point.tsx
* points get passed to App only onBlur now, not on every keypress
* styled ContentEditable and Button (now inline, less obstrusive)