### PR TITLE
* added animate-css-grid as replacement for css transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "^16.9.0",
     "@types/styled-components": "^5.1.0",
     "@types/uuid": "^8.0.0",
+    "animate-css-grid": "^1.4.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",

--- a/src/components/FocusPoint.tsx
+++ b/src/components/FocusPoint.tsx
@@ -53,7 +53,8 @@ const FocusPoint = (props: {
       point: { ...point, content: content },
     });
     appDispatch({
-      type: "setEditingPoint", pointId: undefined,
+      type: "setEditingPoint",
+      pointId: undefined,
     });
   };
 
@@ -111,6 +112,7 @@ const StyledTextArea = styled(TextareaAutosize)`
   border: 0px;
   background-color: transparent;
   font-family: ubuntu;
+  font-size: small;
   outline: 0;
   resize: none;
 `;

--- a/src/components/FocusRegion.tsx
+++ b/src/components/FocusRegion.tsx
@@ -73,26 +73,28 @@ const FocusRegion = (props: {
 
   return (
     <StyledFocusRegion onClick={() => onRegionClick(region, false)}>
-      {point && (
-        <FocusPoint
-          point={point}
-          appDispatch={appDispatch}
-          isEditing={point && editingPoint === point.pointId ? true : false}
-          onEnterPress={() => console.log("enter pressed in focus region")}
-          onClick={() => onRegionClick(region, true)}
-        />
-      )}
-      {!chooseShapes && isExpanded === "expanded" && (
-        <Placeholder
-          text={placeholderText}
-          img={placeholderImg}
-          imgAlt={placeholderImgAlt}
-          onClick={handlePlaceholderClick}
-        />
-      )}
-      {chooseShapes && isExpanded === "expanded" && (
-        <ChooseShapes handleClick={handleChooseShapesClick} />
-      )}
+      <div>
+        {point && (
+          <FocusPoint
+            point={point}
+            appDispatch={appDispatch}
+            isEditing={point && editingPoint === point.pointId ? true : false}
+            onEnterPress={() => console.log("enter pressed in focus region")}
+            onClick={() => onRegionClick(region, true)}
+          />
+        )}
+        {!chooseShapes && isExpanded === "expanded" && (
+          <Placeholder
+            text={placeholderText}
+            img={placeholderImg}
+            imgAlt={placeholderImgAlt}
+            onClick={handlePlaceholderClick}
+          />
+        )}
+        {chooseShapes && isExpanded === "expanded" && (
+          <ChooseShapes handleClick={handleChooseShapesClick} />
+        )}
+      </div>
     </StyledFocusRegion>
   );
 };

--- a/src/components/Point.tsx
+++ b/src/components/Point.tsx
@@ -76,7 +76,8 @@ const Point = (props: {
 
   const handleBlur = () => {
     appDispatch({
-      type: "setEditingPoint", editingPoint: undefined,
+      type: "setEditingPoint",
+      editingPoint: undefined,
     });
   };
 
@@ -147,6 +148,7 @@ const StyledTextArea = styled(TextareaAutosize)`
   border: 0px;
   background-color: transparent;
   font-family: ubuntu;
+  font-size: small;
   outline: 0;
   resize: none;
 `;

--- a/src/components/Region.tsx
+++ b/src/components/Region.tsx
@@ -63,56 +63,58 @@ const Region = (props: {
       backgroundColor={author.styles.backgroundColor}
       onClick={() => onRegionClick(region, false)}
     >
-      {renderPoints.map((p: any, i: number) => (
-        <Point
-          key={p.pointId}
-          point={p}
-          index={i}
-          appDispatch={appDispatch}
-          isEditing={editingPoint === p.pointId}
-          createPointBelow={(topContent, bottomContent) => {
-            appDispatch({
-              type: "splitIntoTwoPoints",
-              topPoint: {
-                author: author,
-                content: topContent,
-                shape: region,
-              },
-              bottomPoint: {
-                author: author,
-                content: bottomContent,
-                shape: region,
-              },
-              index: points.findIndex((p) => p.pointId === editingPoint),
-            });
-          }}
-          combineWithPriorPoint={(point: PointI, index: number) => {
-            appDispatch({
-              type: "combineWithPriorPoint",
-              point: point,
-              index: index,
-            });
-          }}
-          setCursorPositionIndex={
-            setCursorPosition && setCursorPosition.pointId === p.pointId
-              ? !isNaN(setCursorPosition.index)
-                ? setCursorPosition.index
-                : 0
-              : undefined
-          }
-          onClick={() => onRegionClick(region, true)}
-        />
-      ))}
-      {isExpanded === "expanded" && (
-        <Placeholder
-          text={placeholderText}
-          img={placeholderImg}
-          imgAlt={placeholderImgAlt}
-          onClick={() => {
-            createEmptyPoint(region, points.length);
-          }}
-        />
-      )}
+      <div>
+        {renderPoints.map((p: any, i: number) => (
+          <Point
+            key={p.pointId}
+            point={p}
+            index={i}
+            appDispatch={appDispatch}
+            isEditing={editingPoint === p.pointId}
+            createPointBelow={(topContent, bottomContent) => {
+              appDispatch({
+                type: "splitIntoTwoPoints",
+                topPoint: {
+                  author: author,
+                  content: topContent,
+                  shape: region,
+                },
+                bottomPoint: {
+                  author: author,
+                  content: bottomContent,
+                  shape: region,
+                },
+                index: points.findIndex((p) => p.pointId === editingPoint),
+              });
+            }}
+            combineWithPriorPoint={(point: PointI, index: number) => {
+              appDispatch({
+                type: "combineWithPriorPoint",
+                point: point,
+                index: index,
+              });
+            }}
+            setCursorPositionIndex={
+              setCursorPosition && setCursorPosition.pointId === p.pointId
+                ? !isNaN(setCursorPosition.index)
+                  ? setCursorPosition.index
+                  : 0
+                : undefined
+            }
+            onClick={() => onRegionClick(region, true)}
+          />
+        ))}
+        {isExpanded === "expanded" && (
+          <Placeholder
+            text={placeholderText}
+            img={placeholderImg}
+            imgAlt={placeholderImgAlt}
+            onClick={() => {
+              createEmptyPoint(region, points.length);
+            }}
+          />
+        )}
+      </div>
     </StyledRegion>
   );
 };

--- a/src/components/SemanticScreen.tsx
+++ b/src/components/SemanticScreen.tsx
@@ -16,7 +16,7 @@
   You should have received a copy of the GNU General Public License
   along with U4U.  If not, see <https://www.gnu.org/licenses/>.
 */
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { v4 as uuidv4 } from "uuid";
 
@@ -32,6 +32,8 @@ import {
   RegionI,
   SetCursorPositionI,
 } from "../constants/AppState";
+
+import { wrapGrid } from "animate-css-grid";
 
 const SemanticScreen = (props: {
   message: MessageI;
@@ -63,13 +65,6 @@ const SemanticScreen = (props: {
 
   const [expandedRegion, setExpandedRegion] = useState("");
 
- const ref = React.useRef<HTMLDivElement>();
-  const [forceRerender, setForceRerender] = useState();
-  console.log(forceRerender);
- useEffect(() => {
-  ref.current && ref.current.addEventListener('transitionend', () => setForceRerender(Math.random()))
-
- }, [setForceRerender]);
   const createEmptyPoint = (shape: PointShape, index: number) => {
     appDispatch({
       type: "pointCreate",
@@ -149,12 +144,19 @@ const SemanticScreen = (props: {
     "topics",
   ];
 
+  const semanticScreenRef = useRef<HTMLDivElement>();
+
+  useEffect(() => {
+    semanticScreenRef.current &&
+      wrapGrid(semanticScreenRef.current, { duration: 150, easing: "easeIn" });
+  }, []);
+
   return (
     <StyledSemanticScreen
       color={author.styles.textColor}
       expandedRegion={expandedRegion}
       showShapes={showShapes}
-      ref={ref}
+      ref={semanticScreenRef}
     >
       <Banner
         author={author}

--- a/src/components/StyledSemanticScreen.ts
+++ b/src/components/StyledSemanticScreen.ts
@@ -33,7 +33,6 @@ const StyledSemanticScreen = styled.div<Props>`
   color: ${(props) => (props.color ? props.color : "inherit")};
   padding: ${(props) => (props.showShapes ? "2rem" : "0")};
   box-sizing: border-box;
-  transition: 0.25s;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-template-rows: 1fr 1fr 1fr;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,6 +1352,22 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@popmotion/easing@^1.0.1", "@popmotion/easing@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@popmotion/easing/-/easing-1.0.2.tgz#17d925c45b4bf44189e5a38038d149df42d8c0b4"
+  integrity sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==
+
+"@popmotion/popcorn@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@popmotion/popcorn/-/popcorn-0.4.4.tgz#a5f906fccdff84526e3fcb892712d7d8a98d6adc"
+  integrity sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==
+  dependencies:
+    "@popmotion/easing" "^1.0.1"
+    framesync "^4.0.1"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.7"
+    tslib "^1.10.0"
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
@@ -2016,6 +2032,15 @@ alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
+
+animate-css-grid@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/animate-css-grid/-/animate-css-grid-1.4.3.tgz#414cad20c3511538a4d488ab7ac9aa0198d9ebbe"
+  integrity sha512-Yq/5cxm7amQALKCB4/SFJzNQFhLfgJE+lGoy8F131a2uuSF4K4/yCmOYr9jZi1J4KQqAbnilurnBRXkYbOXqvQ==
+  dependencies:
+    "@popmotion/easing" "^1.0.2"
+    lodash.throttle "^4.1.1"
+    popmotion "^8.5.5"
 
 ansi-colors@^3.0.0:
   version "3.2.4"
@@ -4833,6 +4858,14 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+framesync@^4.0.0, framesync@^4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-4.0.4.tgz#79c42c0118f26821c078570db0ff81fb863516a2"
+  integrity sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^1.10.0"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -5173,6 +5206,11 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+hey-listen@^1.0.5, hey-listen@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
+  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -6703,6 +6741,11 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
+
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -7819,6 +7862,19 @@ pnp-webpack-plugin@1.6.4:
   integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
   dependencies:
     ts-pnp "^1.1.6"
+
+popmotion@^8.5.5:
+  version "8.7.3"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-8.7.3.tgz#330a77fd8b288f0e8f930e3d3f351d6eb4897860"
+  integrity sha512-OcpS/V9sCJjrKiVfp3JB5kp5SBqefZ4RvM9GBLYgv0YbULxv9S5METP9ueVJxSClR3yrfFEY2pLWTWKLn/EUfg==
+  dependencies:
+    "@popmotion/easing" "^1.0.1"
+    "@popmotion/popcorn" "^0.4.4"
+    framesync "^4.0.0"
+    hey-listen "^1.0.5"
+    style-value-types "^3.1.7"
+    stylefire "^7.0.1"
+    tslib "^1.10.0"
 
 portfinder@^1.0.25:
   version "1.0.26"
@@ -10027,6 +10083,14 @@ style-loader@0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
+style-value-types@^3.1.7:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-3.1.7.tgz#3d7d3cf9cb9f9ee86c00e19ba65d6a181a0db33a"
+  integrity sha512-jPaG5HcAPs3vetSwOJozrBXxuHo9tjZVnbRyBjxqb00c2saIoeuBJc1/2MtvB8eRZy41u/BBDH0CpfzWixftKg==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^1.10.0"
+
 styled-components@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.1.1.tgz#96dfb02a8025794960863b9e8e365e3b6be5518d"
@@ -10042,6 +10106,17 @@ styled-components@^5.1.1:
     hoist-non-react-statics "^3.0.0"
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
+
+stylefire@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-7.0.3.tgz#9120ecbb084111788e0ddaa04074799750f20d1d"
+  integrity sha512-Q0l7NSeFz/OkX+o6/7Zg3VZxSAZeQzQpYomWmIpOehFM/rJNMSLVX5fgg6Q48ut2ETNKwdhm97mPNU643EBCoQ==
+  dependencies:
+    "@popmotion/popcorn" "^0.4.4"
+    framesync "^4.0.0"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.7"
+    tslib "^1.10.0"
 
 stylehacks@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
* removed prior textarea autosize fix (forced re-render in SemanticScreen)
* wrapped Region's and StyledRegion's children in a plain div (required for animate-css-grid)
* set font-size to small in Point and FocusPoint to compensate for growth resulting from animate-css-grid
* ran prettier