### PR TITLE
* only display shape icons to the left of points when the containing …

### DIFF
--- a/src/components/Point.tsx
+++ b/src/components/Point.tsx
@@ -194,7 +194,7 @@ const Point = (props: {
       isFirst={index === 0 ? true : false}
       onClick={handleClick}
     >
-      <StyledImg
+     {isExpanded === 'expanded' && <StyledImg
         ref={drag}
         src={imageUrl}
         onClick={() => {
@@ -205,7 +205,7 @@ const Point = (props: {
         isMainPoint={isMainPoint}
         height={isMainPoint ? 30 : 20}
         alt={shape}
-      />
+      />}
       <StyledTextArea
         value={point.content}
         onBlur={handleBlur}
@@ -320,6 +320,7 @@ const StyledTextArea = styled(TextareaAutosize)<StyledProps>`
   font-size: ${(props) => (props.isMainPoint ? "medium" : "small")};
   outline: 0;
   resize: none;
+  overflow: hidden;
 `;
 
 export default Point;

--- a/src/components/StyledRegion.ts
+++ b/src/components/StyledRegion.ts
@@ -25,7 +25,8 @@ interface StyledRegionProps {
 
 const StyledRegion = styled.div<StyledRegionProps>`
   background-color: ${(props) => props.backgroundColor};
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   border: 2px solid lightgray;
   border-radius: 10px;
   margin: 0.5px;


### PR DESCRIPTION
…region is expanded

* style changes to reduce unnecessary scrollbars